### PR TITLE
DP-1410 Report latency of latest received event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dataplatform-probe
 Monitoring service for dataplatform services and events
 
-This application continuously sends events to the dataplatform pipeline to test the latency of the pipeline.  
+This application continuously sends events to the dataplatform pipeline to test the latency of the pipeline.
 It requires [Pipenv](https://github.com/pypa/pipenv) to be installed.
 ## Development
 Running this app requires these environment variables to be set:
@@ -47,9 +47,7 @@ These metrics are:
 - **probe_event_post_errors** (Counter): The count of errors experienced when posting events
 - **probe_events_received** (Counter): The count of events received from the pipeline
 - **probe_wrong_appid** (Counter): The count of events received with the wrong App ID(posted by another instance of probe)
-- **probe_max_time_spent** (Gauge): The maximum latency experienced for all the events
-- **probe_min_time_spent** (Gauge): The minimum latency experienced for all the events
-- **probe_avg_time_spent** (Gauge): The average latency experienced for all the events
+- **probe_event_latency** (Gauge): The latency of the latest received event
 
 ## Dependencies
 This application uses the following dependencies:

--- a/probe/run_probe.py
+++ b/probe/run_probe.py
@@ -14,7 +14,8 @@ from origo.event.post_event import PostEvent
 from prometheus_client import start_http_server, Counter
 
 event_post_errors_count = Counter(
-    name=get_metric_name("event_post_errors"), documentation="Count of errors experienced when posting events"
+    name=get_metric_name("event_post_errors"),
+    documentation="Count of errors experienced when posting events",
 )
 
 

--- a/probe/utils.py
+++ b/probe/utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from logging import getLogger, Formatter, StreamHandler, getLevelName
-from math import inf
+
 from prometheus_client import Gauge
 
 log = getLogger()
@@ -21,18 +21,8 @@ def print_header():
 
 
 class EventPrinter:
-    max_time_spent = -inf
-    min_time_spent = inf
-    avg_time_spent = 0.0
-    events_received = 0
-    max_time_spent_gauge = Gauge(
-        name=get_metric_name("events_max_time_spent"), documentation="Maximum event latency"
-    )
-    min_time_spent_gauge = Gauge(
-        name=get_metric_name("events_min_time_spent"), documentation="Minimum event latency"
-    )
-    avg_time_spent_gauge = Gauge(
-        name=get_metric_name("events_avg_time_spent"), documentation="Average event latency"
+    event_latency = Gauge(
+        name=get_metric_name("event_latency"), documentation="Event latency"
     )
 
     def print_event(self, event):
@@ -41,30 +31,4 @@ class EventPrinter:
             f"- Time Received: {datetime.fromisoformat(event['time_received'])} "
             f"- Time Spent(seconds): {event['time_spent']}"
         )
-
-        self.events_received += 1
-        self.max_time_spent = max(self.max_time_spent, event["time_spent"])
-        self.min_time_spent = min(self.min_time_spent, event["time_spent"])
-        self.avg_time_spent = self.avg_time_spent + (
-            (event["time_spent"] - self.avg_time_spent) / self.events_received
-        )
-        self.max_time_spent_gauge.set(self.max_time_spent)
-        self.min_time_spent_gauge.set(self.min_time_spent)
-        self.avg_time_spent_gauge.set(self.avg_time_spent)
-        log.info(f"Max time spent: {round(self.max_time_spent, 2)}s")
-        log.info(f"Min time spent: {round(self.min_time_spent, 2)}s")
-        log.info(f"Average time spent: {round(self.avg_time_spent, 2)}s")
-
-        # t = PrettyTable(["Event ID", 'Time Sent', "Time Received", "Time spent(seconds)"])
-        # for event in events_to_print:
-        #    t.add_row(
-        #        [event['seqno'], datetime.fromisoformat(event['time_sent']),
-        #         datetime.fromisoformat(event['time_received']), event['time_spent']]
-        #    )
-        # log.info(f"Printing {len(events_to_print)} events")
-        # log.info("\n" + str(t))
-
-        # time_spent_values = [event['time_spent'] for event in events_to_print]
-        # log.info(f"Max time spent: {round(max(time_spent_values), 2)}s")
-        # log.info(f"Min time spent: {round(min(time_spent_values), 2)}s")
-        # log.info(f"Average time spent: {round(sum(time_spent_values) / len(time_spent_values), 2)}s")
+        self.event_latency.set(event["time_spent"])


### PR DESCRIPTION
Instead of reporting the minimum, maximum, and average latency of events, report just the latency of the latest received event and let Prometheus take care of the difficult mathsy stuff.