### PR TITLE
DP-2290 Only count sent events in 'missing events' metric

### DIFF
--- a/probe/probe.py
+++ b/probe/probe.py
@@ -87,8 +87,11 @@ class Probe(object):
             ("events_missing_1h_share", (now - timedelta(hours=1))),
         ):
             events = self.get_events_sent_after(timestamp)
-            missing_events = [e for e in events if e.state == EventState.PENDING]
-            share_of_events_missing = len(missing_events) / len(events) * 100
+            sent_events = [e for e in events if e.state != EventState.ERROR]
+            missing_events = [e for e in sent_events if e.state == EventState.PENDING]
+            share_of_events_missing = (
+                len(missing_events) / len(sent_events) * 100 if sent_events else 0.0
+            )
             metric = getattr(self.metrics, metric_attr)
             metric.set(share_of_events_missing)
 

--- a/probe/probe.py
+++ b/probe/probe.py
@@ -87,7 +87,7 @@ class Probe(object):
             ("events_missing_1h_share", (now - timedelta(hours=1))),
         ):
             events = self.get_events_sent_after(timestamp)
-            missing_events = [e for e in events if e.state != EventState.RECEIVED]
+            missing_events = [e for e in events if e.state == EventState.PENDING]
             share_of_events_missing = len(missing_events) / len(events) * 100
             metric = getattr(self.metrics, metric_attr)
             metric.set(share_of_events_missing)


### PR DESCRIPTION
Failed event sends are counted in a different metric and should not
be included in the 'missing events'.